### PR TITLE
[review] backup.rb のテンプレートの修正

### DIFF
--- a/lib/generators/cosuka_opsworks/templates/config/backup.rb
+++ b/lib/generators/cosuka_opsworks/templates/config/backup.rb
@@ -7,7 +7,7 @@ require 'socket'
 require 'dotenv'
 
 rails_env = 'production'
-app_name = 'sample-app-name'
+app_name = 'sample-app-name' # FIXME
 rails_root    = "/srv/www/rails/current"
 log_directory = "#{rails_root}/log"
 
@@ -49,8 +49,6 @@ Encryptor::OpenSSL.defaults do |encryption|
 end
 
 Backup::Model.new(data_file_name_sym, 'App Data Backup') do
-  split_into_chunks_of 4000
-
   database PostgreSQL do |database|
     database.name               = data[rails_env]['database']
     database.username           = data[rails_env]['username']


### PR DESCRIPTION
- テンプレートから変更すべき部分がわかりやすいように FIXME のコメント追加
- `split_into_chunks_of` はS3のファイルサイズ制限が厳しかったときの名残で今はいらないので削除
