### PR TITLE
[review] メンテナンス画面のhtmlを指定可能に

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Rails アプリを OpsWroks で動かす際に以下の機能を提供
 
 - ELB による Healthcheck のための受け口を提供（DB 疎通確認あり）
-- \${RAILS_ROOT}/tmp/stop.txt 配置でメンテナンス画面を表示
+- メンテナンス画面を表示
 - ディスク残容量の監視
 
 ## 注意
@@ -105,11 +105,46 @@ Nginx コネクション数が`80`%以上
 cosuka_opsworks:watch_nginx_connections
 ```
 
+### `cosuka_opsworks:maintenance:start[name]`
+
+メンテナンスモード開始
+
+#### default args
+
+- name: `''`
+
+#### Usage
+
+メンテナンスモード開始(public/503.html を表示)
+
+```
+cosuka_opsworks:maintenance:start
+```
+
+メンテナンスモード開始(public/503_db_upgrade.html を表示)
+
+```
+cosuka_opsworks:maintenance:start[503_db_upgrade]
+```
+
+### `cosuka_opsworks:maintenance:stop`
+
+メンテナンスモード終了
+
+#### Usage
+
+メンテナンスモード終了
+
+```
+cosuka_opsworks:maintenance:stop
+```
+
 ## Github workflows
 
 `rails g cosuka_opsworks` で追加される Github workflows です。
 
 ### cosuka-opsworks-action
-whenever の設定ファイルに変更があれば、crontabの差分をPRにコメントしてくれます。
+
+whenever の設定ファイルに変更があれば、crontab の差分を PR にコメントしてくれます。
 
 see: https://github.com/SonicGarden/cosuka-opsworks-action

--- a/lib/cosuka_opsworks/maintenance.rb
+++ b/lib/cosuka_opsworks/maintenance.rb
@@ -10,7 +10,7 @@ module CosukaOpsworks
     def call(env)
       if maintenance_mode?
         headers = { 'Content-Type' => 'text/html' }
-        [503, headers, File.open([Rails.root, 'public', '503.html'].join('/'))]
+        [503, headers, File.open(maintenance_file_path)]
       else
         @app.call(env)
       end
@@ -19,7 +19,16 @@ module CosukaOpsworks
     private
 
     def maintenance_mode?
-      File.exist?([Rails.root, 'tmp', 'stop.txt'].join('/'))
+      File.exist?(stop_file_path)
+    end
+
+    def maintenance_file_path
+      name = IO.read(stop_file_path).remove(/[^\w-]/).presence || '503'
+      Rails.public_path.join("#{name}.html")
+    end
+
+    def stop_file_path
+      Rails.root.join('tmp/stop.txt')
     end
   end
 end

--- a/lib/cosuka_opsworks/tasks.rb
+++ b/lib/cosuka_opsworks/tasks.rb
@@ -37,4 +37,22 @@ namespace :cosuka_opsworks do
       ENV.replace(original_env)
     end
   end
+
+  namespace :maintenance do
+    desc 'Start maintenance'
+    task :start, [:name] do |_, args|
+      args.with_defaults(name: '')
+      if args[:name].present? && !File.exist?(Rails.public_path.join("#{args[:name]}.html"))
+        raise ArgumentError.new("Invalid name: #{args[:name]}")
+      end
+
+      IO.write(Rails.root.join('tmp/stop.txt'), args[:name])
+    end
+
+    desc 'Stop maintenance'
+    task :stop do
+      path = Rails.root.join('tmp/stop.txt')
+      File.delete(path) if File.exist?(path)
+    end
+  end
 end

--- a/lib/cosuka_opsworks/version.rb
+++ b/lib/cosuka_opsworks/version.rb
@@ -1,3 +1,3 @@
 module CosukaOpsworks
-  VERSION = '0.1.14'.freeze
+  VERSION = '0.2.0'.freeze
 end


### PR DESCRIPTION
これまで通り`touch tmp/stop.txt`と`rm tmp/stop.txt`でも同様に動きます。