### PR TITLE
[review] 非推奨なオプション引数を使わないように

### DIFF
--- a/lib/cosuka_opsworks/version.rb
+++ b/lib/cosuka_opsworks/version.rb
@@ -1,3 +1,3 @@
 module CosukaOpsworks
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.2.1'.freeze
 end

--- a/lib/generators/cosuka_opsworks/templates/config/backup.rb
+++ b/lib/generators/cosuka_opsworks/templates/config/backup.rb
@@ -17,7 +17,7 @@ log_file_name_sym = (host_name + '_log').to_sym
 
 Dotenv.load("#{rails_root}/.env")
 data = YAML.load_file("#{rails_root}/config/database.yml")
-secrets = YAML.safe_load(ERB.new(File.read("#{rails_root}/config/secrets.yml")).result, [], [], true)
+secrets = YAML.safe_load(ERB.new(File.read("#{rails_root}/config/secrets.yml")).result, aliases: true)
 mandrill = secrets[rails_env]['mandrill']
 aws_s3 = secrets[rails_env]['s3']
 


### PR DESCRIPTION
意味は同じで、ruby@2.7〜3.1で問題なく使えることを（ドキュメント上で）確認済み。